### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/MMA845XQ/keywords.txt
+++ b/MMA845XQ/keywords.txt
@@ -6,21 +6,21 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MMA845XQ   KEYWORD1
+MMA845XQ	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin       KEYWORD2
-getX        KEYWORD2
-getY        KEYWORD2
-getZ        KEYWORD2
-getRho      KEYWORD2
-getPhi      KEYWORD2
-getTheta    KEYWORD2
-update      KEYWORD2
-getPLStatus KEYWORD2
+begin	KEYWORD2
+getX	KEYWORD2
+getY	KEYWORD2
+getZ	KEYWORD2
+getRho	KEYWORD2
+getPhi	KEYWORD2
+getTheta	KEYWORD2
+update	KEYWORD2
+getPLStatus	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords